### PR TITLE
Python 3 support as submitted to original author in Jan 2015

### DIFF
--- a/inotifyx/__init__.py
+++ b/inotifyx/__init__.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     import sys
 
     if len(sys.argv) == 1:
-        print >>sys.stderr, 'usage: inotify path [path ...]'
+        sys.stderr.write("usage: inotify path [path ...]\n")
         sys.exit(1)
 
     paths = sys.argv[1:]
@@ -146,7 +146,7 @@ if __name__ == '__main__':
                     parts = [event.get_mask_description()]
                     if event.name:
                         parts.append(event.name)
-                    print '%s: %s' % (path, ' '.join(parts))
+                    print('%s: %s' % (path, ' '.join(parts)))
         except KeyboardInterrupt:
             pass
 

--- a/inotifyx/binding.c
+++ b/inotifyx/binding.c
@@ -271,6 +271,25 @@ static PyMethodDef InotifyMethods[] = {
 };
 
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "inotifyx.binding",  /* m_name */
+    "Low-level interface to inotify.  Do not use this module directly.\n"
+    "Instead, use the inotifyx module.",     /* m_doc */
+    -1,                  /* m_size */
+    InotifyMethods,      /* m_methods */
+    NULL,                /* m_reload */
+    NULL,                /* m_traverse */
+    NULL,                /* m_clear */
+    NULL,                /* m_free */
+};
+PyMODINIT_FUNC PyInit_binding(void) {
+    PyObject* module = PyModule_Create(&moduledef);
+
+    if (module == NULL)
+        return NULL;
+#else
 PyMODINIT_FUNC initbinding(void) {
     PyObject* module = Py_InitModule3(
       "inotifyx.binding",
@@ -283,7 +302,9 @@ PyMODINIT_FUNC initbinding(void) {
 
     if (module == NULL)
         return;
-    
+
+#endif /* else PY_MAJOR_VERSION >= 3 */
+
     PyModule_AddIntConstant(module, "IN_ACCESS", IN_ACCESS);
     PyModule_AddIntConstant(module, "IN_MODIFY", IN_MODIFY);
     PyModule_AddIntConstant(module, "IN_ATTRIB", IN_ATTRIB);
@@ -307,4 +328,7 @@ PyMODINIT_FUNC initbinding(void) {
     PyModule_AddIntConstant(module, "IN_ISDIR", IN_ISDIR);
     PyModule_AddIntConstant(module, "IN_ONESHOT", IN_ONESHOT);
     PyModule_AddIntConstant(module, "IN_ALL_EVENTS", IN_ALL_EVENTS);
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
 }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # Author: Forest Bond
 # This file is in the public domain.
 
-import os, sys, commands
+import os, sys, subprocess
 from distutils.core import Extension
 
 
@@ -22,9 +22,11 @@ def get_version(release_file):
         finally:
             f.close()
     except (IOError, OSError):
-        status, output = commands.getstatusoutput('bzr revno')
-        if status == 0:
-            return 'bzr%s' % output.strip()
+        try:
+            output = subprocess.check_output(['bzr', 'revno'])
+            return 'bzr' + output.strip()
+        except:
+            pass
     return 'unknown'
 
 

--- a/setuplib.py
+++ b/setuplib.py
@@ -216,8 +216,8 @@ class _DistinfoMixin:
 
     def _prepare_distinfo_string(self, value):
         if isinstance(value, str):
-            value = unicode(value)
-        return unicode(repr(value)).encode('utf-8')
+            value = u'' + value
+        return u'' + repr(value).encode('utf-8')
 
     def _write_distinfo_module(self, outfile, distinfo = (), imports = ()):
         distinfo = list(distinfo)
@@ -236,16 +236,16 @@ class _DistinfoMixin:
             log.info(' %s = %s', k, v)
 
         if not self.dry_run:
-            with open(outfile, 'wb') as f:
-                f.write('# coding: utf-8\n')
-                f.write('\n')
-                for modname in imports:
-                    f.write('import %s\n' % modname)
-                if imports:
-                    f.write('\n')
-                for k, v in distinfo:
-                    f.write('%s = %s\n' % (k, v))
+            text = '# coding: utf-8\n\n'
+            for modname in imports:
+                text += 'import %s\n' % modname
+            if imports:
+                text += '\n'
+            for k, v in distinfo:
+                text += '%s = %s\n' % (k, v)
 
+            with open(outfile, 'wb') as f:
+                f.write(text.encode('utf-8'))
 
 ###
 
@@ -359,7 +359,7 @@ class install_data(_install_data):
 
     def _gen_data_files(self, base_dir, data_files):
         for arg in data_files:
-            print arg
+            print(arg)
             if isinstance(arg, basestring):
                 yield (base_dir, [arg])
             else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,4 +46,4 @@ def main(**kwargs):
 
 def print_names(test_names = None):
     from tests.manager import manager
-    print '\n'.join(manager.get_names(test_names))
+    print('\n'.join(manager.get_names(test_names)))

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -77,10 +77,8 @@ class TestManager(object):
             import coverage as _coverage
 
             if int(_coverage.__version__.split('.')[0]) < 3:
-                print >>sys.stderr, (
-                  'warning: coverage versions < 3 '
-                  'are known to produce imperfect results'
-                )
+                sys.stderr.write('warning: coverage versions < 3 ' +
+                    'are known to produce imperfect results\n')
 
             _coverage.use_cache(False)
             _coverage.start()
@@ -94,7 +92,7 @@ class TestManager(object):
             for test in self.tests:
                 if self.should_run_test(test, test_names):
                     if print_only:
-                        print test.id()
+                        print(test.id())
                     else:
                         suite.addTest(test)
 


### PR DESCRIPTION
This is the original comment I sent to the inotifyx author a couple of years ago.

---------

Forest,

I made use of your inotifyx package in my process manager "taskforce".  I recently converted taskforce to support python3 and found inotifyx doesn't yet support it.  I figured the changes shouldn't be too difficult so I went ahead.  I'm not very familiar with launchpad (I've only ever used github) so I've just attached the tarball of changes to inotifyx-0.2.2.

The updated version supports python2 and python3.  It passes your tests in both environments (as well as my taskforce tests FWIW).

The files changed are:

inotifyx/binding.c	-  Converted to handle python3-style bindings with ifdefs.
inotifyx/__init__.py	-  Use print consistent with python2 and python3
tests/__init__.py	-  Use unicode consistent with python2 and python3
tests/manager.py	-  Replace 'commands' module with 'subprocess' module
setuplib.py		-  Use print consistent with python2 and python3
setup.py		-  Use print consistent with python2 and python3


Hopefully you can make use of these.  This is my first dive into python bindings, so please review the changes carefully, but I do believe they are clean.  I used info at http://lucumr.pocoo.org/2014/1/5/unicode-in-2-and-3/ for the changes to bindings.c.

Regards,

Andy Fullford
